### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/sieraleannetharp/e6a82933-8060-4199-a25f-59d430a88e0b/97f5b774-3273-436e-a651-fef0f699a060/_apis/work/boardbadge/8739f974-fdfe-4d5d-aa04-a6f81389b44a)](https://dev.azure.com/sieraleannetharp/e6a82933-8060-4199-a25f-59d430a88e0b/_boards/board/t/97f5b774-3273-436e-a651-fef0f699a060/Microsoft.RequirementCategory)
 # GitHub Codespaces ♥️ React
 
 Welcome to your shiny new Codespace running React! We've got everything fired up and running for you to explore React.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/sieraleannetharp/e6a82933-8060-4199-a25f-59d430a88e0b/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.